### PR TITLE
Remove unnecessary 'this' in demo

### DIFF
--- a/demo/src/main.js
+++ b/demo/src/main.js
@@ -16,7 +16,7 @@ const main = document.querySelector('main');
 let i = 0;
 
 function update() {
-	render(<App this={SvelteThing} count={i++}/>, main);
+	render(<App count={i++}/>, main);
 	setTimeout(update, 1000);
 }
 


### PR DESCRIPTION
Demo seems to work without the `this` prop given to the `App` component.