### PR TITLE
Remove extra prop from demo

### DIFF
--- a/demo/src/main.js
+++ b/demo/src/main.js
@@ -16,7 +16,7 @@ const main = document.querySelector('main');
 let i = 0;
 
 function update() {
-	render(<App this={SvelteThing} count={i++}/>, main);
+	render(<App count={i++}/>, main);
 	setTimeout(update, 1000);
 }
 


### PR DESCRIPTION
If I understand correctly, the App component doesn't need the `this` prop, since it's provided to the `SvelteComponent` inside the `App`. Seeing it in both places was kinda confusing at first glance.